### PR TITLE
chore: use enable-funding for venmo onetime payments

### DIFF
--- a/client-one-time-payments.html
+++ b/client-one-time-payments.html
@@ -9,7 +9,7 @@
     <body>
         <div id="paypal-button-container"></div>
         <!-- Replace "client-id=test" with your PayPal Client ID -->
-        <script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD"></script>
+        <script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD&enable-funding=venmo"></script>
 
         <script>
             const paypalButtonsComponent = paypal.Buttons({

--- a/client-standalone-one-time.html
+++ b/client-standalone-one-time.html
@@ -9,7 +9,7 @@
     <body>
         <div id="paypal-button-container" style="max-width: 500px"></div>
         <!-- Replace "client-id=test" with your PayPal Client ID -->
-        <script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD"></script>
+        <script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD&enable-funding=venmo"></script>
 
         <script>
             const fundingSources = [


### PR DESCRIPTION
This PR adds `enable-funding` to the one-time payment examples. This way Venmo will continue to show up when the merchant changes the client-id from `test` to another one.